### PR TITLE
Specify region when setting up the boto3 client.

### DIFF
--- a/tenableio2securityhub.py
+++ b/tenableio2securityhub.py
@@ -310,7 +310,7 @@ def get_assets ():
 
 
 # Create a SecurityHub client
-securityhub = boto3.client("securityhub")
+securityhub = boto3.client("securityhub", region_name=AWS_REGION)
 
 
 # Collect AWS Instance vulnerabilities from Tenable.io


### PR DESCRIPTION
As is, you will run into a boto error

> botocore.exceptions.NoRegionError: You must specify a region.

This change sets up the boto3 client with the region specified by the user.