### PR TITLE
fix_arn_owner_id

### DIFF
--- a/sechubingest.py
+++ b/sechubingest.py
@@ -222,7 +222,7 @@ class SecurityHubIngester(object):
                 'Type': 'AwsEc2Instance',
                 'Id': 'arn:aws:ec2:{}:{}:instance:{}'.format(
                     asset.get('aws_region'),
-                    self._account_id,
+                    asset.get('aws_owner_id'),
                     asset.get('aws_ec2_instance_id')),
                 'Region': asset.get('aws_region'),
                 'Details': {'AwsEc2Instance': details},


### PR DESCRIPTION
Id ARN is getting constructed using the AWS Account Id where the script is running (`--aws-account-id`). This is an error, AWS Security Hub could be aggregating from different AWS Accounts. The AWS Account Id for the EC2 ARN should came from the Asset.